### PR TITLE
[codex] Add issue template fallback

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+Describe the issue, request, or documentation problem.
+
+## Context
+
+Include the page, command, environment, browser, or deployment URL involved.
+
+## Expected
+
+What should happen?
+
+## Actual
+
+What happened instead?
+
+## Notes
+
+Do not include secrets, access tokens, private logs, real customer data, or real personal data.


### PR DESCRIPTION
## Summary
- Add a simple Markdown issue template fallback so GitHub community profile detects an issue template
- Keep the detailed issue forms already added in .github/ISSUE_TEMPLATE

## Validation
- Documentation-only change; no runtime checks needed